### PR TITLE
Test: E2E - Add Manifest to existing Work.

### DIFF
--- a/tests/e2e/apply_test.go
+++ b/tests/e2e/apply_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	workapi "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 )
 
@@ -33,9 +34,12 @@ const (
 )
 
 var _ = ginkgo.Describe("Apply Work", func() {
+
+	workName := "work-" + utilrand.String(5)
+	workNamespace := "default"
+
 	ginkgo.Context("Create a service and deployment", func() {
 		ginkgo.It("Should create work successfully", func() {
-			workNamespace = "default"
 
 			manifestFiles := []string{
 				"testmanifests/test-deployment.yaml",
@@ -44,7 +48,7 @@ var _ = ginkgo.Describe("Apply Work", func() {
 
 			work := &workapi.Work{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-work",
+					Name:      workName,
 					Namespace: workNamespace,
 				},
 				Spec: workapi.WorkSpec{
@@ -54,18 +58,7 @@ var _ = ginkgo.Describe("Apply Work", func() {
 				},
 			}
 
-			for _, file := range manifestFiles {
-				fileRaw, err := testManifestFiles.ReadFile(file)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-				obj, _, err := genericCodec.Decode(fileRaw, nil, nil)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-				work.Spec.Workload.Manifests = append(
-					work.Spec.Workload.Manifests, workapi.Manifest{
-						RawExtension: runtime.RawExtension{Object: obj},
-					})
-			}
+			addManifestsToWorkSpec(manifestFiles, &work.Spec)
 
 			_, err := hubWorkClient.MulticlusterV1alpha1().Works(workNamespace).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -81,7 +74,48 @@ var _ = ginkgo.Describe("Apply Work", func() {
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				work, err := hubWorkClient.MulticlusterV1alpha1().Works(workNamespace).Get(context.Background(), "test-work", metav1.GetOptions{})
+				work, err := hubWorkClient.MulticlusterV1alpha1().Works(workNamespace).Get(context.Background(), workName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				if !meta.IsStatusConditionTrue(work.Status.Conditions, "Applied") {
+					return fmt.Errorf("Expect the applied contidion of the work is true")
+				}
+
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		})
+	})
+	ginkgo.Context("Add a manifest to an existing work", func() {
+		ginkgo.It("Should create new resources successfully.", func() {
+			manifestFiles := []string{
+				"testmanifests/test-deployment2.yaml",
+				"testmanifests/test-service2.yaml",
+			}
+
+			// Get existing work, then add the new manifests
+			work, err := hubWorkClient.MulticlusterV1alpha1().Works(workNamespace).Get(context.Background(), workName, metav1.GetOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(work).ToNot(gomega.BeNil())
+
+			addManifestsToWorkSpec(manifestFiles, &work.Spec)
+
+			_, err = hubWorkClient.MulticlusterV1alpha1().Works(workNamespace).Update(context.Background(), work, metav1.UpdateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			gomega.Eventually(func() error {
+				_, err := spokeKubeClient.AppsV1().Deployments("default").Get(context.Background(), "test-nginx2", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				_, err = spokeKubeClient.CoreV1().Services("default").Get(context.Background(), "test-nginx2", metav1.GetOptions{})
+				return err
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
+			gomega.Eventually(func() error {
+				work, err := hubWorkClient.MulticlusterV1alpha1().Works(workNamespace).Get(context.Background(), workName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -95,3 +129,18 @@ var _ = ginkgo.Describe("Apply Work", func() {
 		})
 	})
 })
+
+func addManifestsToWorkSpec(manifestFileRelativePaths []string, workSpec *workapi.WorkSpec) {
+	for _, file := range manifestFileRelativePaths {
+		fileRaw, err := testManifestFiles.ReadFile(file)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		obj, _, err := genericCodec.Decode(fileRaw, nil, nil)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		workSpec.Workload.Manifests = append(
+			workSpec.Workload.Manifests, workapi.Manifest{
+				RawExtension: runtime.RawExtension{Object: obj},
+			})
+	}
+}

--- a/tests/e2e/apply_test.go
+++ b/tests/e2e/apply_test.go
@@ -36,7 +36,7 @@ const (
 var _ = ginkgo.Describe("Apply Work", func() {
 
 	workName := "work-" + utilrand.String(5)
-	workNamespace := "default"
+	workNamespace = "default"
 
 	ginkgo.Context("Create a service and deployment", func() {
 		ginkgo.It("Should create work successfully", func() {

--- a/tests/e2e/testmanifests/test-deployment2.yaml
+++ b/tests/e2e/testmanifests/test-deployment2.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-nginx2
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: test-nginx2
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: test-nginx2
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 8080

--- a/tests/e2e/testmanifests/test-service2.yaml
+++ b/tests/e2e/testmanifests/test-service2.yaml
@@ -1,0 +1,27 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nginx2
+  namespace: default
+  labels:
+    run: test-nginx2
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+  selector:
+    run: test-nginx


### PR DESCRIPTION
### Description of your changes
Added a new e2e test scenario for adding new manifests to an existing Work object.

I have:
- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Running e2e test.