### PR TITLE
Refactor:  Change the e2e suite to have a default setup and clean for Ginkgo It blocks.

### DIFF
--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -38,11 +38,11 @@ import (
 )
 
 var (
-	workNamespace      string
 	restConfig         *rest.Config
+	hubKubeClient      kubernetes.Interface
+	hubWorkClient      workclientset.Interface
 	spokeKubeClient    kubernetes.Interface
 	spokeDynamicClient dynamic.Interface
-	hubWorkClient      workclientset.Interface
 
 	//go:embed testmanifests
 	testManifestFiles embed.FS
@@ -75,14 +75,15 @@ var _ = ginkgo.BeforeSuite(func() {
 	restConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-	spokeKubeClient, err = kubernetes.NewForConfig(restConfig)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-	spokeDynamicClient, err = dynamic.NewForConfig(restConfig)
+	hubKubeClient, err = kubernetes.NewForConfig(restConfig)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	hubWorkClient, err = workclientset.NewForConfig(restConfig)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
+	spokeKubeClient, err = kubernetes.NewForConfig(restConfig)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	spokeDynamicClient, err = dynamic.NewForConfig(restConfig)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 })


### PR DESCRIPTION
### Description of your changes
Change the e2e suite to have a default setup and clean for Ginkgo It blocks.

I have:
- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
e2e runs 100% locally.