### PR TITLE
Test: Added different namespaced manifests e2e test.

### DIFF
--- a/tests/e2e/apply_test.go
+++ b/tests/e2e/apply_test.go
@@ -237,7 +237,7 @@ var _ = ginkgo.Describe("Apply Work", func() {
 		})
 	})
 	ginkgo.Context("Work created on the hub, with manifests which should be applied into different namespaces.", func() {
-		ginkgo.It("Should reapply the manifest.", func() {
+		ginkgo.It("Should apply manifests in two different namespaces.", func() {
 			// Setup
 			namespace := &v1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{

--- a/tests/e2e/apply_test.go
+++ b/tests/e2e/apply_test.go
@@ -262,6 +262,14 @@ var _ = ginkgo.Describe("Apply Work", func() {
 				_, err := spokeKubeClient.CoreV1().Namespaces().Get(context.Background(), "test-namespace", metav1.GetOptions{})
 				return err
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+			gomega.Eventually(func() error {
+				_, err := spokeKubeClient.CoreV1().ConfigMaps("default").Get(context.Background(), "test-configmap", metav1.GetOptions{})
+				return err
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+			gomega.Eventually(func() error {
+				_, err := spokeKubeClient.CoreV1().ConfigMaps("test-namespace").Get(context.Background(), "test-configmap", metav1.GetOptions{})
+				return err
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			// Reset
 			err = deleteWork(createdWork)

--- a/tests/e2e/testmanifests/test-configmap2.yaml
+++ b/tests/e2e/testmanifests/test-configmap2.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+  namespace: test-namespace
+data:
+  fielda: one


### PR DESCRIPTION
### Description of your changes
Added e2e test for work with manifests that are set to different name.

I have:
- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Local e2e test run at 100% success. 