### PR TITLE
Test: Added E2E test that replaces an entire Work resource's manifest collection.

### DIFF
--- a/tests/e2e/apply_test.go
+++ b/tests/e2e/apply_test.go
@@ -138,7 +138,7 @@ var (
 
 					By("adding the new manifest to the Work resource and updating it on the hub")
 					Eventually(func() error {
-						addManifestsToWorkSpec([]string{manifests[2]}, &work.Spec)
+						addManifestsToWorkSpec([]string{manifests[3], manifests[4]}, &work.Spec)
 						_, err = updateWork(work)
 						return err
 					}, eventuallyTimeout, eventuallyInterval).ShouldNot(HaveOccurred())
@@ -272,6 +272,57 @@ var (
 
 						return err
 					}, eventuallyTimeout, eventuallyInterval).ShouldNot(HaveOccurred())
+				})
+			})
+			Context("with all new manifests", func() {
+				It("should delete all previously applied resources", func() {
+					manifests = []string{"testmanifests/test-serviceaccount.yaml"}
+					manifestMetaName = []string{"test-serviceaccount"}
+					manifestMetaNamespaces = []string{"default"}
+					aResourceStillExists := true
+
+					// Get the current AppliedWork, so we can verify the previously applied resources have been deleted.
+					time.Sleep(3 * time.Second) // Time for the AppliedWork to be updated by the reconciler.
+					appliedWork, getError = spokeWorkClient.MulticlusterV1alpha1().AppliedWorks().Get(context.Background(), createdWork.Name, metav1.GetOptions{})
+
+					// Get the Work resource and update replace its manifests.
+					createdWork, getError = hubWorkClient.MulticlusterV1alpha1().Works(createdWork.Namespace).Get(context.Background(), createdWork.Name, metav1.GetOptions{})
+					Expect(getError).ShouldNot(HaveOccurred())
+
+					createdWork.Spec.Workload.Manifests = nil
+					addManifestsToWorkSpec([]string{manifests[0]}, &createdWork.Spec)
+					createdWork, updateError = hubWorkClient.MulticlusterV1alpha1().Works(createdWork.Namespace).Update(context.Background(), createdWork, metav1.UpdateOptions{})
+					Expect(updateError).ShouldNot(HaveOccurred())
+
+					By("checking to see if all previously applied works have been deleted", func() {
+						Eventually(func() bool {
+							for aResourceStillExists == true {
+								for _, ar := range appliedWork.Status.AppliedResources {
+									gvr := schema.GroupVersionResource{
+										Group:    ar.Group,
+										Version:  ar.Version,
+										Resource: ar.Resource,
+									}
+
+									_, getError = spokeDynamicClient.Resource(gvr).Namespace(ar.Namespace).Get(context.Background(), ar.Name, metav1.GetOptions{})
+									if getError != nil {
+										aResourceStillExists = false
+									} else {
+										aResourceStillExists = true
+									}
+								}
+							}
+							return aResourceStillExists
+						}, eventuallyTimeout, eventuallyInterval).ShouldNot(BeTrue())
+					})
+
+					By("verifying the new manifest was applied", func() {
+						Eventually(func() error {
+							_, getError = spokeKubeClient.CoreV1().ServiceAccounts(manifestMetaNamespaces[0]).Get(context.Background(), manifestMetaName[0], metav1.GetOptions{})
+
+							return getError
+						}, eventuallyTimeout, eventuallyInterval).ShouldNot(HaveOccurred())
+					})
 				})
 			})
 		})

--- a/tests/e2e/testmanifests/test-serviceaccount.yaml
+++ b/tests/e2e/testmanifests/test-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-serviceaccount
+  namespace: default


### PR DESCRIPTION
### Description of your changes

Added an E2E test that takes a Work that has had all its existing manifests applied to the member cluster, and replaces it with a new set of manifests. The test verifies that the previous collection of manifests are garbage collected from the member cluster and the new manifest is applied.

Fixes #

I have:

- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
 100% success via local e2e testing

### Special notes for your reviewer
There is some refactoring needed to make the tests more efficient and remove the thread sleeping. But for now these tests are following the same pattern so as to focus on e2e validation. 