### PR TITLE
Fix: Updated CodeCov action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,6 @@ jobs:
       - name: Upload report
         uses: codecov/codecov-action@v2.1.0
         with:
-          ## Repository upload token - get it from codecov.io. Required only for private repositories
-          token: ${{ secrets.CODECOV_TOKEN }}
           ## Comma-separated list of files to upload
           files: ./cover.out
           flags: ci-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           ## Comma-separated list of files to upload
-          files: ./cover.out
+          files: go/src/sigs.k8s.io/work-api/cover.out
           flags: ci-tests
           name: codecov-umbrella
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,14 @@ jobs:
           GOPATH: ${{ env.GO_PATH }}
 
       - name: Upload report
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3
         with:
           ## Comma-separated list of files to upload
           files: ./cover.out
           flags: ci-tests
           name: codecov-umbrella
+          fail_ci_if_error: true
+          verbose: true
 
   e2e:
     name: e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
           flags: ci-tests
           name: codecov-umbrella
           fail_ci_if_error: true
-          verbose: true
 
   e2e:
     name: e2e


### PR DESCRIPTION
### Description of your changes
Removing CodeCov token from workflow as the repo is public; only private repos need a token.

### I have:
- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.