### PR TITLE
Test: Added CRD creation E2E test.

### DIFF
--- a/tests/e2e/testmanifests/test-crd.yaml
+++ b/tests/e2e/testmanifests/test-crd.yaml
@@ -1,0 +1,45 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testcrds.multicluster.x-k8s.io
+spec:
+  group: multicluster.x-k8s.io
+  names:
+    kind: TestCRD
+    listKind: TestCRDList
+    plural: testcrds
+    singular: testcrd
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      "schema":
+        "openAPIV3Schema":
+          description: A test CRD for the WorkAPI.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec represents the desired configuration of TestCRD.
+              type: object
+              required:
+                - tesetprop
+              properties:
+                testprop:
+                  description: A test property.
+                  type: string
+            status:
+              description: Status represents the current status of TestCRD
+              type: object


### PR DESCRIPTION
### Description of your changes
Added new E2E test that adds a CRD via the work API.

I have:
- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
100% local e2e testing success.