### PR TITLE
Fix: Updated CI workflow to execute when pushed into master / release-*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI Workflow
 on:
+  push:
+    branches:
+      - master
+      - release-*
   pull_request:
     branches:
       - master


### PR DESCRIPTION
### Description of your changes
Updated ci workflow to run when a push occurs into master or release-*.

- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.