### PR TITLE
Fix: Work Status controller - Integration test fix

### DIFF
--- a/pkg/controllers/work_status_controller_integration_test.go
+++ b/pkg/controllers/work_status_controller_integration_test.go
@@ -136,11 +136,14 @@ var _ = Describe("Work Status Reconciler", func() {
 	Context("Receives a request where a Work's manifest condition exists, but there"+
 		" isn't a respective AppliedResourceMeta.", func() {
 		It("Resource is deleted from the AppliedResources of the AppliedWork", func() {
-			currentAppliedWork, err := workClient.MulticlusterV1alpha1().AppliedWorks().Get(context.Background(), workName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			currentAppliedWork.Status.AppliedResources = []workv1alpha1.AppliedResourceMeta{}
-			_, err = workClient.MulticlusterV1alpha1().AppliedWorks().Update(context.Background(), currentAppliedWork, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() error {
+				currentAppliedWork, err := workClient.MulticlusterV1alpha1().AppliedWorks().Get(context.Background(), workName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				currentAppliedWork.Status.AppliedResources = []workv1alpha1.AppliedResourceMeta{}
+				_, err = workClient.MulticlusterV1alpha1().AppliedWorks().Update(context.Background(), currentAppliedWork, metav1.UpdateOptions{})
+				return err
+			}, timeout, interval).ShouldNot(HaveOccurred())
 
 			Eventually(func() bool {
 				currentAppliedWork, err := workClient.MulticlusterV1alpha1().AppliedWorks().Get(context.Background(), workName, metav1.GetOptions{})


### PR DESCRIPTION
### Description of your changes
Fixed test by wrapping an async routine in an eventual check.

I have:
- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Local tests run.