### PR TITLE
Feat: add work resource type const

### DIFF
--- a/pkg/apis/v1alpha1/work_types.go
+++ b/pkg/apis/v1alpha1/work_types.go
@@ -22,6 +22,7 @@ import (
 )
 
 const WorkKind = "Work"
+const WorkResource = "works"
 
 // WorkSpec defines the desired state of Work
 type WorkSpec struct {


### PR DESCRIPTION
### Description of your changes

Add work resource for the fleet repo to consume

I have:

- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->