### PR TITLE
Fix: Fixed the issue for missing ordinal in the appliedResource field

### DIFF
--- a/pkg/apis/v1alpha1/work_types.go
+++ b/pkg/apis/v1alpha1/work_types.go
@@ -65,7 +65,7 @@ type WorkStatus struct {
 type ResourceIdentifier struct {
 	// Ordinal represents an index in manifests list, so the condition can still be linked
 	// to a manifest even thougth manifest cannot be parsed successfully.
-	Ordinal int `json:"ordinal,omitempty"`
+	Ordinal int `json:"ordinal"`
 
 	// Group is the group of the resource.
 	Group string `json:"group,omitempty"`


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #
https://github.com/Azure/k8s-work-api/issues/77

I have:
- Changed the type of the Resource Identifier's ordinal to be mandatory.
  - This fixes the problem of ordinal not showing up on AppliedResources (due to ordinal == 0)
  - Also makes ordinal mandatory, which should also help reduce errors when manifests are created.
  Here is the screenshot of the ordinal showing up now: 
<img width="233" alt="Screen Shot 2022-07-26 at 3 37 23 PM" src="https://user-images.githubusercontent.com/5618644/181124150-d79f7b2f-b089-4475-a847-17f096c511ce.png">
- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure
 this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->