### PR TITLE
Feat: Allowing work namespace to be chosen by the users.

### DIFF
--- a/deploy-work-api/templates/fleet-work-controller.yaml
+++ b/deploy-work-api/templates/fleet-work-controller.yaml
@@ -36,7 +36,7 @@ spec:
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "--work-namespace=default"
+            - "--work-namespace={{ .Values.workNamespace }}"
             - "--hub-kubeconfig-secret=hub-kubeconfig-secret"
           ports:
             - name: http

--- a/deploy-work-api/values.yaml
+++ b/deploy-work-api/values.yaml
@@ -46,5 +46,5 @@ service:
   type: ClusterIP
   port: 8080
 
-## @param kubeconfig base64 encoded hub-cluster kubeconfig
-kubeconfig: XXXXXXXXXXXXXXXXXXX==
+## @param work.namespace Namespace to fetch work from
+workNamespace: default


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #
The cause of the problem: https://github.com/Azure/k8s-work-api/issues/91

I have:
- Allowed users to install the helm chart using the work namespace of their choice.
  - If the users do not choose to specify a work namespace, "default" namespace will be chosen by default.
  - The command is:
    - helm install --set workNamespace="[Namespace]" deploy-work-api deploy-work-api/ -n fleet-system
- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->