### PR TITLE
Fix: Allowing AppliedWorks to be recreated after it has been manually deleted

### DIFF
--- a/pkg/controllers/finalize_controller.go
+++ b/pkg/controllers/finalize_controller.go
@@ -66,7 +66,7 @@ func (r *FinalizeWorkReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.garbageCollectAppliedWork(ctx, work)
 	}
 
-	var appliedWork *workv1alpha1.AppliedWork
+	appliedWork := &workv1alpha1.AppliedWork{}
 	if controllerutil.ContainsFinalizer(work, workFinalizer) {
 		err = r.spokeClient.Get(ctx, req.NamespacedName, appliedWork)
 		if err != nil {


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The logic already existed for the AppliedWork recreation.
The problem was that when we set the appliedWork to be a var object, 
instead of going into the correct error of "Not Found",
it was causing a "Nil Pointer" error. 

Fixes #

I have:
- Changed the var object of the AppliedWorks to be a pointer of the empty object.
- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->