### PR TITLE
Fix: Adding 5 min to the reconciliation loop for apply_controller.go

### DIFF
--- a/pkg/controllers/apply_controller.go
+++ b/pkg/controllers/apply_controller.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -166,7 +167,7 @@ func (r *ApplyWorkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		utils.EventReasonReconcileComplete,
 		utils.MessageManifestApplyComplete)
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: time.Minute * 5}, nil
 }
 
 // applyManifests processes a given set of Manifests by: setting ownership, validating the manifest, and passing it on for application to the cluster.

--- a/pkg/controllers/apply_controller_unit_test.go
+++ b/pkg/controllers/apply_controller_unit_test.go
@@ -466,6 +466,7 @@ func TestReconcile(t *testing.T) {
 		reconciler ApplyWorkReconciler
 		req        ctrl.Request
 		wantErr    error
+		requeue    bool
 	}{
 		"work cannot be retrieved, client failed due to client error": {
 			reconciler: ApplyWorkReconciler{
@@ -618,6 +619,7 @@ func TestReconcile(t *testing.T) {
 			},
 			req:     req,
 			wantErr: nil,
+			requeue: true,
 		},
 	}
 	for testName, testCase := range testCases {
@@ -626,7 +628,10 @@ func TestReconcile(t *testing.T) {
 			if testCase.wantErr != nil {
 				assert.Containsf(t, err.Error(), testCase.wantErr.Error(), "incorrect error for Testcase %s", testName)
 			} else {
-				assert.Equal(t, ctrl.Result{RequeueAfter: time.Minute * 5}, ctrlResult, "incorrect ctrlResult for Testcase %s", testName)
+				if testCase.requeue {
+					assert.Equal(t, ctrl.Result{RequeueAfter: time.Minute * 5}, ctrlResult, "incorrect ctrlResult for Testcase %s", testName)
+				}
+				assert.Equalf(t, false, ctrlResult.Requeue, "incorrect ctrlResult for Testcase %s", testName)
 			}
 		})
 	}

--- a/pkg/controllers/apply_controller_unit_test.go
+++ b/pkg/controllers/apply_controller_unit_test.go
@@ -626,7 +626,7 @@ func TestReconcile(t *testing.T) {
 			if testCase.wantErr != nil {
 				assert.Containsf(t, err.Error(), testCase.wantErr.Error(), "incorrect error for Testcase %s", testName)
 			} else {
-				assert.Equalf(t, false, ctrlResult.Requeue, "incorrect ctrlResult for Testcase %s", testName)
+				assert.Equal(t, ctrl.Result{RequeueAfter: time.Minute * 5}, ctrlResult, "incorrect ctrlResult for Testcase %s", testName)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #
https://github.com/Azure/k8s-work-api/issues/82
I have:

- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->