### PR TITLE
fix: reconcile appliedWork status no matter what

### DIFF
--- a/pkg/controllers/applied_work_syncer.go
+++ b/pkg/controllers/applied_work_syncer.go
@@ -93,7 +93,6 @@ func (r *ApplyWorkReconciler) generateDiff(ctx context.Context, work *workapi.Wo
 			}
 		}
 	}
-
 	return newRes, staleRes, nil
 }
 


### PR DESCRIPTION
### Description of your changes

fix the bug that we stop applied work status if work apply has error


I have:

- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
IT

### Special notes for your reviewer