### PR TITLE
fix: the nil crash and ignore ordinal in compare resources

### DIFF
--- a/cmd/workcontroller/workcontroller.go
+++ b/cmd/workcontroller/workcontroller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+
 	"sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 	"sigs.k8s.io/work-api/pkg/controllers"
 	"sigs.k8s.io/work-api/version"

--- a/pkg/controllers/apply_controller.go
+++ b/pkg/controllers/apply_controller.go
@@ -169,7 +169,7 @@ func (r *ApplyWorkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// we periodically reconcile the work to make sure the member cluster state is in sync with the work
-	// if the reconcile succeeds
+	// even if the reconciling succeeds in case the resources on the member cluster is removed/changed.
 	return ctrl.Result{RequeueAfter: time.Minute * 5}, err
 }
 

--- a/pkg/controllers/owner_reference_util.go
+++ b/pkg/controllers/owner_reference_util.go
@@ -66,5 +66,5 @@ func isReferSameObject(a, b metav1.OwnerReference) bool {
 		return false
 	}
 
-	return aGV.Group == bGV.Group && a.Kind == b.Kind && a.Name == b.Name
+	return aGV.Group == bGV.Group && aGV.Version == bGV.Version && a.Kind == b.Kind && a.Name == b.Name
 }

--- a/pkg/utils/test_utils.go
+++ b/pkg/utils/test_utils.go
@@ -17,8 +17,6 @@ limitations under the License.
 package utils
 
 import (
-	"github.com/onsi/gomega/format"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -27,27 +25,4 @@ func NewFakeRecorder(bufferSize int) *record.FakeRecorder {
 	recorder := record.NewFakeRecorder(bufferSize)
 	recorder.IncludeObject = true
 	return recorder
-}
-
-// AlreadyExistMatcher matches the error to be already exist
-type AlreadyExistMatcher struct {
-}
-
-// Match matches error.
-func (matcher AlreadyExistMatcher) Match(actual interface{}) (success bool, err error) {
-	if actual == nil {
-		return false, nil
-	}
-	actualError := actual.(error)
-	return apierrors.IsAlreadyExists(actualError), nil
-}
-
-// FailureMessage builds an error message.
-func (matcher AlreadyExistMatcher) FailureMessage(actual interface{}) (message string) {
-	return format.Message(actual, "to be already exist")
-}
-
-// NegatedFailureMessage builds an error message.
-func (matcher AlreadyExistMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return format.Message(actual, "not to be already exist")
 }

--- a/script/README.md
+++ b/script/README.md
@@ -1,1 +1,5 @@
 work_creation.py creates an example work 'n' number of times. The correct usage is: python3 work_creation.py n where n is the number of works to be created.
+
+
+../fleet/hack/tools/bin/goimports-latest -local sigs.k8s.io/work-api -w $(go list -f {{.Dir}} ./...)
+../fleet/hack/tools/bin/staticcheck ./...

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -18,6 +18,9 @@ package e2e
 
 import (
 	"embed"
+	"os"
+	"testing"
+
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -31,13 +34,12 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
 	"sigs.k8s.io/work-api/pkg/apis/v1alpha1"
-	"testing"
 )
 
 var (


### PR DESCRIPTION
### Description of your changes

Fixes
1.  The not handling error on getting the stale resource
2. Take ordinal into account when we compare resource identifier

I have:

- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Added UT

### Special notes for your reviewer
