### PR TITLE
fix: Creation of manifest should not be seen as "ManifestUpdated"

### DIFF
--- a/pkg/controllers/apply_controller.go
+++ b/pkg/controllers/apply_controller.go
@@ -323,7 +323,7 @@ func (r *ApplyWorkReconciler) applyUnstructured(ctx context.Context, gvr schema.
 			ctx, manifestObj, metav1.CreateOptions{FieldManager: workFieldManagerName})
 		if err == nil {
 			klog.V(4).InfoS("successfully created the manifest", "gvr", gvr, "manifest", manifestRef)
-			return actual, true, nil
+			return actual, false, nil
 		}
 		return nil, false, err
 	}


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #
 - Previously, Successful application of manifest would update the condition of the work "Applied" to succeed, with a reason of "AppliedManifestUpdated" instead of original notion of "AppliedManifestComplete".
 This change will make sure the correct reason is shown when resource is created.
I have:

- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->